### PR TITLE
Add --only-matching option

### DIFF
--- a/src/find_secrets.rs
+++ b/src/find_secrets.rs
@@ -54,7 +54,7 @@ fn combined_regex(regexes: &[&str]) -> String {
     combined
 }
 
-pub fn find_secrets(paths: &[PathBuf], strict_ignore: bool) -> Result<usize, Box<dyn Error>> {
+pub fn find_secrets(paths: &[PathBuf], strict_ignore: bool, only_matching: bool) -> Result<usize, Box<dyn Error>> {
     let predefined = predefined_secret_regexes();
     let combined = combined_regex(&predefined);
 
@@ -99,7 +99,9 @@ pub fn find_secrets(paths: &[PathBuf], strict_ignore: bool) -> Result<usize, Box
 
     parallel_walker.run(move || {
         let bufwtr = bufwtr.clone();
-        let mut printer = printer::Standard::new(bufwtr.buffer());
+        let mut printer_builder = printer::StandardBuilder::new();
+        printer_builder.only_matching(only_matching);
+        let mut printer = printer_builder.build(bufwtr.buffer());
         let matcher = matcher.clone();
         let mut searcher = Searcher::new();
         let match_count_result = match_count_result.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,7 @@ secrets into version control.
 USAGE:
     secrets [--strict-ignore] [PATH ...]
     secrets --install-pre-commit
+    secrets --only-matching
     secrets --help
     secrets --version
 
@@ -69,14 +70,22 @@ OPTIONS:
         will be scanned by default. --strict-ignore will override this
         behavior and not search the paths passed as arguments that are excluded
         by the .secretsignore file. This is useful when invoking secrets as a
-        pre-commit.", env!("CARGO_PKG_VERSION"))
+        pre-commit.
+
+    --only-matching
+        Print only the matched (non-empty) parts of a matching line, with each such
+        part on a separate output line.", env!("CARGO_PKG_VERSION"))
     } else {
         let mut strict_ignore = false;
+        let mut only_matching = false;
         let mut paths = Vec::new();
         if args.len() > 1 {
             let mut start_idx = 1;
             if args[1] == "--strict-ignore" {
                 strict_ignore = true;
+                start_idx = 2;
+            } else if args[1] == "--only-matching" {
+                only_matching = true;
                 start_idx = 2;
             }
             for path in &args[start_idx..] {
@@ -86,7 +95,7 @@ OPTIONS:
         if paths.len() == 0 {
             paths.push(PathBuf::from("."));
         }
-        match_count = find_secrets::find_secrets(&paths, strict_ignore)?;
+        match_count = find_secrets::find_secrets(&paths, strict_ignore, only_matching)?;
     }
 
     return Ok(match_count);


### PR DESCRIPTION
Add only-matching option to only output matching parts of the string (similar to how rg goes it).

I had to replace `printer::Standard` with `printer::StandardBuilder` in order to achieve that - hope it's not an issue.