### PR TITLE
adds an informal warning against using both flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ fn main() {
     };
 
     if args.install_pre_commit && args.strict_ignore {
-        eprintln!("Error: Cannot use both --strict-ignore and --install-pre-commit.\n\t--strict-ignore is always used when automatically installing the pre-commit hook. Use `--install-pre-commit` alone.");
+        eprintln!("Error: --strict-ignore not a valid option when installing pre-commits. Use --install-pre-commit alone");
         process::exit(2);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,11 @@ fn main() {
         args.paths
     };
 
+    if args.install_pre_commit && args.strict_ignore {
+        eprintln!("Error: Cannot use both --strict-ignore and --install-pre-commit.\n\t--strict-ignore is always used when automatically installing the pre-commit hook. Use `--install-pre-commit` alone.");
+        process::exit(2);
+    }
+
     if args.install_pre_commit {
         for path in paths {
             match pre_commit::install_pre_commit(&path) {


### PR DESCRIPTION
One issue with PR #15 is if user runs `ripsecrets --install-pre-commit --strict-ignore` (see https://github.com/sirwart/ripsecrets/pull/15#issuecomment-1106872423)

Since the `--install-pre-commit` flag _always_ ignores `.secretsignore`file(s), running `ripsecrets --install-pre-commit` is effectively the same as running `ripsecrets --install-pre-commit --strict-ignore`. And in fact, the same code is called from `main.rs`.

In an effort to avoid some possible confusion for users, this PR makes the tool print an informal error message and exit if a user runs `ripsecrets --install-pre-commit --strict-ignore`:

```text
Error: Cannot use both --strict-ignore and --install-pre-commit.
        --strict-ignore is always used when automatically installing the pre-commit hook. Use `--install-pre-commit` alone.
```

Obviously the language and formatting can be tweaked, but I thought it was important to note this issue here in a PR. 

I'm also curious whether `ripsecrets` should _always_ respect `.secretsignore` files? Or at least respect them by default? 