### PR TITLE
Uses FXHash, rather than Rust's default hasher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +150,15 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "globset"
@@ -474,6 +489,7 @@ name = "ripsecrets"
 version = "0.1.3"
 dependencies = [
  "clap",
+ "fxhash",
  "grep",
  "ignore",
  "memoize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ termcolor = "1.1.2"
 memoize = "0.3.0"
 tempfile = "3.3.0"
 clap = { version = "3.1.10", features = ["derive"] }
+fxhash = "0.2.1"

--- a/src/p_random.rs
+++ b/src/p_random.rs
@@ -1,5 +1,5 @@
-use std::collections::hash_map::HashMap;
-use std::collections::hash_set::HashSet;
+use fxhash::FxHashMap;
+use fxhash::FxHashSet;
 
 use memoize::memoize;
 
@@ -23,7 +23,7 @@ pub fn p_random(s: &[u8]) -> f64 {
 fn p_random_bigrams(s: &[u8]) -> f64 {
     let bigrams_bytes = b"er,te,an,en,ma,ke,10,at,/m,on,09,ti,al,io,.h,./,..,ra,ht,es,or,tm,pe,ml,re,in,3/,n3,0F,ok,ey,00,80,08,ss,07,15,81,F3,st,52,KE,To,01,it,2B,2C,/E,P_,EY,B7,se,73,de,VP,EV,to,od,B0,0E,nt,et,_P,A0,60,90,0A,ri,30,ar,C0,op,03,ec,ns,as,FF,F7,po,PK,la,.p,AE,62,me,F4,71,8E,yp,pa,50,qu,D7,7D,rs,ea,Y_,t_,ha,3B,c/,D2,ls,DE,pr,am,E0,oc,06,li,do,id,05,51,40,ED,_p,70,ed,04,02,t.,rd,mp,20,d_,co,ro,ex,11,ua,nd,0C,0D,D0,Eq,le,EF,wo,e_,e.,ct,0B,_c,Li,45,rT,pt,14,61,Th,56,sT,E6,DF,nT,16,85,em,BF,9E,ne,_s,25,91,78,57,BE,ta,ng,cl,_t,E1,1F,y_,xp,cr,4F,si,s_,E5,pl,AB,ge,7E,F8,35,E2,s.,CF,58,32,2F,E7,1B,ve,B1,3D,nc,Gr,EB,C6,77,64,sl,8A,6A,_k,79,C8,88,ce,Ex,5C,28,EA,A6,2A,Ke,A7,th,CA,ry,F0,B6,7/,D9,6B,4D,DA,3C,ue,n7,9C,.c,7B,72,ac,98,22,/o,va,2D,n.,_m,B8,A3,8D,n_,12,nE,ca,3A,is,AD,rt,r_,l-,_C,n1,_v,y.,yw,1/,ov,_n,_d,ut,no,ul,sa,CT,_K,SS,_e,F1,ty,ou,nG,tr,s/,il,na,iv,L_,AA,da,Ty,EC,ur,TX,xt,lu,No,r.,SL,Re,sw,_1,om,e/,Pa,xc,_g,_a,X_,/e,vi,ds,ai,==,ts,ni,mg,ic,o/,mt,gm,pk,d.,ch,/p,tu,sp,17,/c,ym,ot,ki,Te,FE,ub,nL,eL,.k,if,he,34,e-,23,ze,rE,iz,St,EE,-p,be,In,ER,67,13,yn,ig,ib,_f,.o,el,55,Un,21,fi,54,mo,mb,gi,_r,Qu,FD,-o,ie,fo,As,7F,48,41,/i,eS,ab,FB,1E,h_,ef,rr,rc,di,b.,ol,im,eg,ap,_l,Se,19,oS,ew,bs,Su,F5,Co,BC,ud,C1,r-,ia,_o,65,.r,sk,o_,ck,CD,Am,9F,un,fa,F6,5F,nk,lo,ev,/f,.t,sE,nO,a_,EN,E4,Di,AC,95,74,1_,1A,us,ly,ll,_b,SA,FC,69,5E,43,um,tT,OS,CE,87,7A,59,44,t-,bl,ad,Or,D5,A_,31,24,t/,ph,mm,f.,ag,RS,Of,It,FA,De,1D,/d,-k,lf,hr,gu,fy,D6,89,6F,4E,/k,w_,cu,br,TE,ST,R_,E8,/O";
     let bigrams = bigrams_bytes.split(|b| *b == ',' as u8);
-    let bigrams_set = HashSet::<_>::from_iter(bigrams);
+    let bigrams_set = FxHashSet::<_>::from_iter(bigrams);
 
     let mut num_bigrams = 0;
     for i in 0..s.len() - 1 {
@@ -82,7 +82,7 @@ fn p_random_distinct_values(s: &[u8]) -> f64 {
 }
 
 fn count_distinct_values(s: &[u8]) -> usize {
-    let mut values_count = HashMap::<u8, usize>::new();
+    let mut values_count = FxHashMap::<u8, usize>::default();
     for b in s {
         let count = values_count.entry(*b).or_insert(0);
         *count += 1;


### PR DESCRIPTION
Uses [FxHash](https://docs.rs/fxhash/0.2.1/fxhash/) rather than Rust's default hasher, in an attempt to improve performance. 

My tests have been a bit inconclusive, so would appreciate it if others compared these changes to the main branch in whatever way they think best. FxHash might even be a touch slower in some cases? I'm not sure. 

There are definitely other hashers that may be worth exploring, like [ahash](https://docs.rs/ahash/latest/ahash/index.html). Maybe alternatives to try can be discussed in the comments here.  
