### PR TITLE
Fix typo in pre-commit file name

### DIFF
--- a/src/pre_commit.rs
+++ b/src/pre_commit.rs
@@ -43,7 +43,7 @@ pub fn install_pre_commit(repo_root: &Path) -> Result<(), Box<dyn Error>> {
         }
         write_pre_commit_file(&pre_commit_dir_fname)?;
     } else {
-        let pre_commit_fname = hooks_dir.join("pre_commit");
+        let pre_commit_fname = hooks_dir.join("pre-commit");
 
         if !pre_commit_fname.exists() {
             write_pre_commit_file(&pre_commit_fname)?;


### PR DESCRIPTION
If no `pre_commit_dir` exists the `--install-pre-commit` option creates a pre-commit hook with the file name `pre_commit` in `.git/hooks/` resulting in the pre-commit hook not working. This pr fixes the typo.