### PR TITLE
re-works src/main.rs to better handle errors.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -105,11 +105,9 @@ fn run() -> RunResult {
         RunResult::PreCommitInstallSuccessful
     } else {
         match find_secrets::find_secrets(&paths, args.strict_ignore, args.only_matching) {
-            // If we found 0 secrets, return an exit code of 0
             Ok(0) => RunResult::NoSecretsFound,
             // If we found 1 or more secrets, it's not an error, BUT we don't
-            // want to simply return exit code 0 to main()
-            // Instead, return an exit code of 1 to main()
+            // want to notify the user via a different exit code.
             Ok(_num_secrets) => RunResult::SecretsFound,
             // If there's a real error, return it as a String for main()
             // to handle.

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ fn run() -> RunResult {
     } else {
         match find_secrets::find_secrets(&paths, args.strict_ignore, args.only_matching) {
             Ok(0) => RunResult::NoSecretsFound,
-            // If we found 1 or more secrets, it's not an error, BUT we don't
+            // If we found 1 or more secrets, it's not an error, BUT we do
             // want to notify the user via a different exit code.
             Ok(_num_secrets) => RunResult::SecretsFound,
             // If there's a real error, return it as a String for main()


### PR DESCRIPTION
Has `main` return Rust's `Result` rather than "raw" exit codes, which I think will provide more cross-platform compatibility. It's also more in-line with common Rust patterns, as I understand them. 

Also removes `impl std::error::Error for UsageError {}`, which I didn't see being used anywhere but I could be wrong. 

I'll note here that [the very new Rust 1.61 introduces a more sophisticated error code wrapper](https://blog.rust-lang.org/2022/05/19/Rust-1.61.0.html#custom-exit-codes-from-main).