### PR TITLE
Publish benchmarks to GitHub Pages

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,34 @@
+---
+name: Benchmark
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    name: Run and publish benchmarks
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: cachix/install-nix-action@v17
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - name: Delete Markdown files from submodule to avoid Jekyll errors
+        run: find benches -name "*.md" -delete
+      - name: Run benchmark
+        run: |
+          nix develop
+          cargo bench --bench find_secrets -- --output-format bencher >benchmark.txt 2>/dev/null
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1.14.0
+        with:
+          tool: cargo
+          output-file-path: benchmark.txt
+          # Access token to deploy GitHub Pages branch
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Push and deploy GitHub Pages branch automatically
+          auto-push: true

--- a/benches/find_secrets.rs
+++ b/benches/find_secrets.rs
@@ -2,16 +2,22 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use ripsecrets::find_secrets;
 use std::path::PathBuf;
 use std::time::Duration;
+use termcolor::{BufferWriter, ColorChoice};
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("Find secrets in getsentry/sentry");
-    group
-        .sample_size(30)
-        .measurement_time(Duration::new(15, 0));
+    group.sample_size(30).measurement_time(Duration::new(15, 0));
     let paths = &[PathBuf::from("./benches/getsentry/sentry")];
 
     group.bench_function("find_secrets function", |b| {
-        b.iter(|| find_secrets(black_box(paths), false, false))
+        b.iter(|| {
+            find_secrets(
+                black_box(paths),
+                false,
+                false,
+                BufferWriter::stderr(ColorChoice::Never),
+            )
+        })
     });
 }
 

--- a/benches/find_secrets.rs
+++ b/benches/find_secrets.rs
@@ -6,7 +6,9 @@ use termcolor::{BufferWriter, ColorChoice};
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("Find secrets in getsentry/sentry");
-    group.sample_size(30).measurement_time(Duration::new(15, 0));
+    group
+        .sample_size(10)
+        .measurement_time(Duration::new(120, 0));
     let paths = &[PathBuf::from("./benches/getsentry/sentry")];
 
     group.bench_function("find_secrets function", |b| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,12 @@ fn combined_regex(regexes: &[&str]) -> String {
     combined
 }
 
-pub fn find_secrets(paths: &[PathBuf], strict_ignore: bool, only_matching: bool) -> Result<usize, Box<dyn Error>> {
+pub fn find_secrets(
+    paths: &[PathBuf],
+    strict_ignore: bool,
+    only_matching: bool,
+    writer: BufferWriter,
+) -> Result<usize, Box<dyn Error>> {
     let predefined = predefined_secret_regexes();
     let combined = combined_regex(&predefined);
 
@@ -66,7 +71,7 @@ pub fn find_secrets(paths: &[PathBuf], strict_ignore: bool, only_matching: bool)
     let match_count = Arc::new(AtomicUsize::new(0));
     let match_count_result = match_count.clone();
 
-    let bufwtr = Arc::new(BufferWriter::stdout(ColorChoice::Never));
+    let bufwtr = Arc::new(writer);
 
     let mut to_search = Vec::<PathBuf>::new();
     if strict_ignore && ignore_info.ignore_matcher.is_some() {
@@ -168,7 +173,12 @@ mod tests {
 
     #[test]
     fn no_false_positives() {
-        let res = find_secrets(&[PathBuf::from("test/none")], false, false);
+        let res = find_secrets(
+            &[PathBuf::from("test/none")],
+            false,
+            false,
+            BufferWriter::stdout(ColorChoice::Never),
+        );
         assert_eq!(res.unwrap(), 0)
     }
 
@@ -177,7 +187,12 @@ mod tests {
         for maybe_entry in fs::read_dir("test/one_per_line").unwrap() {
             let entry = maybe_entry.unwrap();
             let contents = fs::read_to_string(entry.path()).unwrap();
-            let res = find_secrets(&[entry.path()], false, false);
+            let res = find_secrets(
+                &[entry.path()],
+                false,
+                false,
+                BufferWriter::stdout(ColorChoice::Never),
+            );
             assert_eq!(
                 res.unwrap(),
                 contents.matches("\n").count(),
@@ -187,14 +202,24 @@ mod tests {
         }
         for maybe_entry in fs::read_dir("test/one_per_file").unwrap() {
             let entry = maybe_entry.unwrap();
-            let res = find_secrets(&[entry.path()], false, false);
+            let res = find_secrets(
+                &[entry.path()],
+                false,
+                false,
+                BufferWriter::stdout(ColorChoice::Never),
+            );
             assert_eq!(res.unwrap(), 1, "{:?}", entry.file_name());
         }
     }
 
     #[test]
     fn strict_ignore_works() {
-        let res = find_secrets(&[PathBuf::from("test")], true, false);
+        let res = find_secrets(
+            &[PathBuf::from("test")],
+            true,
+            false,
+            BufferWriter::stdout(ColorChoice::Never),
+        );
         assert_eq!(res.unwrap(), 0);
 
         let res = find_secrets(
@@ -204,6 +229,7 @@ mod tests {
             ],
             true,
             false,
+            BufferWriter::stdout(ColorChoice::Never),
         );
         assert_eq!(res.unwrap(), 0);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 use ripsecrets::find_secrets;
 use std::path::PathBuf;
 use std::process;
+use termcolor::{BufferWriter, ColorChoice};
 
 mod pre_commit;
 
@@ -101,7 +102,12 @@ fn run() -> RunResult {
         // Made it through all the paths just fine
         RunResult::PreCommitInstallSuccessful
     } else {
-        match find_secrets(&paths, args.strict_ignore, args.only_matching) {
+        match find_secrets(
+            &paths,
+            args.strict_ignore,
+            args.only_matching,
+            BufferWriter::stdout(ColorChoice::Never),
+        ) {
             Ok(0) => RunResult::NoSecretsFound,
             // If we found 1 or more secrets, it's not an error, BUT we do
             // want to notify the user via a different exit code.


### PR DESCRIPTION
On each commit to `main`, run benchmarks and publish them to the `gh-pages` branch. That branch can be configured as the source of GitHub Pages, so it gets built and published on each change. See https://lafrenierejm.github.io/ripsecrets/dev/bench/ for an example of benchmarks published from my fork.