### PR TITLE
Build Docker image and publish to Hub on tag

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,10 +13,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: cachix/install-nix-action@v17
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+      - uses: cachix/install-nix-action@v18
       - name: Delete Markdown files from submodule to avoid Jekyll errors
         run: find benches -name "*.md" -delete
       - name: Run benchmark

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,18 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v17
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+      - uses: cachix/install-nix-action@v18
       - run: nix build
   check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v17
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+      - uses: cachix/install-nix-action@v18
       - run: |
           nix flake check --no-build --show-trace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+---
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The tag to emulate'
+        required: true
+        type: string
+
+jobs:
+  determine-tag:
+    name: Determine tag to use
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.on-push.outputs.tag }}
+      input: ${{ steps.on-workflow.outputs.tag }}
+      version: ${{ steps.combine.outputs.version }}
+
+    steps:
+      - name: Use Git ref
+        id: on-push
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          echo "tag=${{ github.ref }}" >> $GITHUB_OUTPUT
+
+      - name: Use workflow input
+        id: on-workflow
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+
+      - name: Determine actual tag
+        id: combine
+        run: |
+          REF=${{ steps.on-push.outputs.tag }}
+          INPUT=${{ steps.on-workflow.outputs.tag }}
+          if [[ -n "$REF" ]]; then
+            echo "version=${REF:1}" >> $GITHUB_OUTPUT
+          elif [[ -n "$INPUT" ]]; then
+            echo "version=${INPUT:1}" >> $GITHUB_OUTPUT
+          fi
+
+  build-oci:
+    name: Build OCI image
+    runs-on: ubuntu-latest
+    needs:
+      - determine-tag
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install and configure Nix
+        uses: cachix/install-nix-action@v18
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Build the OCI tar.gz
+        run: nix build .#oci
+
+      - name: Temporarily save the OCI archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: oci-tar-gz-${{ needs.determine-tag.outputs.version }}
+          path: result
+          retention-days: 1
+
+  publish-oci:
+    name: Push to Docker Hub
+    runs-on: ubuntu-latest
+    needs:
+      - determine-tag
+      - build-oci
+
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Retrieve OCI archive
+        uses: actions/download-artifact@v3
+        with:
+          name: oci-tar-gz-${{ needs.determine-tag.outputs.version }}
+          path: .
+
+      - name: Docker load
+        run: |
+          docker load --input result
+
+      - name: Docker tag
+        run: |
+          docker tag ripsecrets ${{ github.repository }}:${{ needs.determine-tag.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,9 +56,6 @@ jobs:
 
       - name: Install and configure Nix
         uses: cachix/install-nix-action@v18
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
 
       - name: Build the OCI tar.gz
         run: nix build .#oci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,3 +97,7 @@ jobs:
       - name: Docker tag
         run: |
           docker tag ripsecrets ${{ github.repository }}:${{ needs.determine-tag.outputs.version }}
+
+      - name: Docker push
+        run: |
+          docker push ${{ github.repository }}:${{ needs.determine-tag.outputs.version }}

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,17 @@
         };
         defaultPackage = packages.ripsecrets;
 
+        # `nix build .#oci`
+        packages.oci = pkgs.dockerTools.buildImage {
+          name = "ripsecrets";
+          tag = "latest";
+          config = {
+            Entrypoint = [ "${packages.ripsecrets}/bin/ripsecrets" ];
+            WorkingDir = "/data";
+            Volumes = { "/data" = { }; };
+          };
+        };
+
         # `nix run`
         apps.ripsecrets = flake-utils.lib.mkApp { drv = packages.ripsecrets; };
         defaultApp = apps.ripsecrets;


### PR DESCRIPTION
This adds a GitHub Actions workflow for building and uploading a Docker image to Docker hub. The workflow is triggered when a new tag is added or it can be run manually. The prerequisites are
- a Docker Hub account with the same username as GitHub;
- a Docker Hub repository with the same name as the repository (in this case "ripsecrets", though forks can rename); and
- the Docker Hub username and a write token saved in GitHub Secrets as `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`, respectively.

See <https://hub.docker.com/r/lafrenierejm/ripsecrets/tags> for an example of an image built from the [corresponding workflow](https://github.com/lafrenierejm/ripsecrets/actions/runs/3579351735) on my fork.

The main limitation of this current approach is that the image that's built and uploaded is _not_ multi-arch. The workflow is currently configured to run only on x86_64 Linux, so as of now that is the only architecture supported by the resulting image.
