### PR TITLE
Improve pre-commit framework docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,30 +83,29 @@ $ nix profile install github:sirwart/ripsecrets
 
 ### Using `pre-commit`
 
-`ripsecrets` can work as a plugin for [pre-commit](https://pre-commit.com/) with
-the following configuration.
-
-There are two hooks provided:
-
-- `ripsecrets` - This hook requires having Cargo and a Rust compiler already installed.
-   See the [pre-commit rust plugin docs](https://pre-commit.com/#rust) for more
-   information.
-- `ripsecrets-system` - This hook requires having `ripsecrets` installed and available
-   on through other means, e.g. your package manager or
-   [a prebuilt, binary release](https://github.com/sirwart/ripsecrets/releases)
-   otherwise on your PATH. This is ideal if you wish to avoid installing a Rust environment.
+`ripsecrets` works as a hook for [the pre-commit framework](https://pre-commit.com/).
+Add the following to your `.pre-commit-config.yaml` file:
 
 ```yaml
 repos:
--   repo: https://github.com/sirwart/ripsecrets.git
-    # Set your version, be sure to use the latest and update regularly or use 'main'
-    rev: v0.1.5
+-   repo: https://github.com/sirwart/ripsecrets
+    rev: v0.1.5  # Use latest tag on GitHub
     hooks:
-    # use this one when you have a rust environment available
     -   id: ripsecrets
-    # use this one when you will install ripsecrets with a package manager
-    # -   id: ripsecrets-system
 ```
+
+There are two hooks available:
+
+- `ripsecrets` (Recommended)
+
+   pre-commit will set up a Rust environment from scratch to compile and run ripsecrets.
+   See the [pre-commit rust plugin docs](https://pre-commit.com/#rust) for more information.
+
+- `ripsecrets-system`
+
+   pre-commit will look for `ripsecrets` on your `PATH`.
+   This hook requires you to install ripsecrets separately, e.g. with your package manager or [a prebuilt binary release](https://github.com/sirwart/ripsecrets/releases).
+   Only recommended if you are happy making all repository users install `ripsecrets` manually.
 
 ## Ignoring secrets
 


### PR DESCRIPTION
Hi @sirwart , thanks for the great tool. I'm just writing up a book section on how to set up ripsecrets, via pre-commit, and I thought I'd try improve the instructions in the repo whilst I'm at it.

I made these improvements:

1. Improve some terminology - pre-commit uses "hooks" not "plugins"
2. Remove advice about updating regularly - I think this applies to all pre-commit users, who should be aware of the `pre-commit autoupdate` command, or use pre-commit.ci that runs this for you.
3. Show the sample config first, then explain the options.
4. Edit to recommend the `ripsecrets` hook, because since version 2.21.0, pre-commit can bootstrap Rust if it is unavailable ([pre-commit PR](https://github.com/pre-commit/pre-commit/pull/2534), [open docs improvement PR](https://github.com/pre-commit/pre-commit.com/pull/783)). This should make the `ripsecrets` hook preferable to `ripsecrets-system`.