### PR TITLE
Added hex key detection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ fn predefined_secret_regexes() -> Vec<&'static str> {
         r#"sq0csp-[0-9A-Za-z\\\-_]{43}"#,             // square
         "AIzaSy[A-Za-z0-9-_]{33}",                    // gcp api key
         "glpat-[A-Za-z0-9_/-]{20,}",                  // gitlab
+        "[0-9a-fA-F]{16,}",                           // hex
         // Private keys
         "AGE-SECRET-KEY-[A-Z0-9]{59}", // age secret key
         "-----BEGIN DSA PRIVATE KEY-----(?:$|[^-]{63}[^-]*-----END)",


### PR DESCRIPTION
Currently ripsecrets doesn't detect api keys that are purely hex. I have a few keys that are hex and weren't detected at all, and I think they either should be detected by ripsecrets, or there should be an option to detect them. It's measured randomness is incredibly low - I'm guessing because of the limited character set? 

You can easily generate a hex key similar to what I was looking for with
```bash
openssl rand -hex 36
```

This is undetected presumably because its hex and it's too predictable
```python
API_KEY = '9e51341f8d87894c927d0150be0a9676c7427850c11607bb2e8943292a029a91ebed6a91'
```

This regex will detect sequences of hex that are 16 characters or longer
```python
[0-9a-fA-F]{16,}
```

My proposed solution is to detect hex sequences 16 characters or longer. 
The reasoning is that there are likely few cases where such a sequence of characters would exist, and _not_ be a secret. 8 characters might honestly be a better choice.

I wasn't really sure how you'd want it to be implemented, my PR at least worked in my testing.
I made sure that the regex is only compiled once for performance. I tried to make the fewest number of changes possible. I haven't done performance benchmarks to measure it's impact.

I'd love to know your thoughts on this.