### PR TITLE
Correct the name of OCI Nix package in release GHA workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         uses: cachix/install-nix-action@v18
 
       - name: Build the OCI tar.gz
-        run: nix build .#oci
+        run: nix build .#ripsecrets-oci
 
       - name: Temporarily save the OCI archive
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
See [here](https://github.com/lafrenierejm/ripsecrets/actions/runs/6387521064) for an example of a successful workflow run.