### PR TITLE
Move documentation from README to CLI usage text

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'The tag to emulate'
+        description: "The tag to emulate"
         required: true
         type: string
 

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,3 @@
+{
+  "line-length": false
+}

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,3 +1,4 @@
 {
+  "blanks-around-fence": false,
   "line-length": false
 }

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,18 +1,18 @@
--   id: ripsecrets
-    name: ripsecrets
-    description: 'Prevent committing secret keys into your source code'
-    entry: ripsecrets
-    language: rust
-    'types': [text]
-    args: [--strict-ignore]
-    require_serial: true
-    minimum_pre_commit_version: '0'
--   id: ripsecrets-system
-    name: ripsecrets
-    description: 'Prevent committing secret keys into your source code'
-    entry: ripsecrets
-    language: system
-    'types': [text]
-    args: [--strict-ignore]
-    require_serial: true
-    minimum_pre_commit_version: '0'
+- id: ripsecrets
+  name: ripsecrets
+  description: "Prevent committing secret keys into your source code"
+  entry: ripsecrets
+  language: rust
+  "types": [text]
+  args: [--strict-ignore]
+  require_serial: true
+  minimum_pre_commit_version: "0"
+- id: ripsecrets-system
+  name: ripsecrets
+  description: "Prevent committing secret keys into your source code"
+  entry: ripsecrets
+  language: system
+  "types": [text]
+  args: [--strict-ignore]
+  require_serial: true
+  minimum_pre_commit_version: "0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## 0.1.7 (2023-09-11)
 
 - Add detection for secrets in database connection strings and other URLs

--- a/README.md
+++ b/README.md
@@ -20,21 +20,44 @@
 
 ## Usage
 
-By default, running `ripsecrets` will recursively search source files in your current directory for secrets.
+### CLI
 
-```shell
-ripsecrets
+<!-- `$ printf "%s\n%b" '$ ripsecrets --help' "$(nix run .# -- --help 2>/dev/null)"` as console -->
+```console
+$ ripsecrets --help
+ripsecrets searches files and directories recursively for secret API keys.
+
+ripsecrets is primarily designed to be used as a pre-commit to prevent committing secrets into version control.
+
+For every secret it finds, ripsecrets will print out the file, line number, and the secret that was found.  If ripsecrets finds any secrets, it will exit with a non-zero status code.
+
+You can optionally pass a list of files and directories to search as arguments.  This is most commonly used to search files that are about to be committed to source control for accidentally included secrets.
+
+Usage: ripsecrets [OPTIONS] [Source files]...
+
+Arguments:
+  [Source files]...
+          Source files. Can be files or directories. Defaults to '.'
+
+Options:
+      --install-pre-commit
+          Install `ripsecrets` as a pre-commit hook automatically in git directory provided. Defaults to '.'
+
+      --strict-ignore
+          If you pass a path as an argument that's ignored by .secretsignore it will be scanned by default. --strict-ignore will override this behavior and not search the paths passed as arguments that are excluded by the .secretsignore file. This is useful when invoking secrets as a pre-commit
+
+      --only-matching
+          Print only the matched (non-empty) parts of a matching line, with each such part on a separate output line
+
+      --additional-pattern <ADDITIONAL_PATTERNS>
+          Additional regex patterns used to find secrets. If there is a matching group in the regex the matched group will be tested for randomness before being reported as a secret
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 ```
-
-For every secret it finds, it will print out the file, line number, and the secret that was found. If it finds any secrets, it will exit with a non-zero status code.
-
-You can optionally pass a list of files and directories to search as arguments.
-
-```shell
-ripsecrets file1 file2 dir1
-```
-
-This is most commonly used to search files that are about to be committed to source control for accidentally included secrets.
 
 ### Installing ripsecrets as a pre-commit hook
 

--- a/README.md
+++ b/README.md
@@ -22,31 +22,31 @@
 
 By default, running `ripsecrets` will recursively search source files in your current directory for secrets.
 
-```
-$ ripsecrets
+```shell
+ripsecrets
 ```
 
 For every secret it finds, it will print out the file, line number, and the secret that was found. If it finds any secrets, it will exit with a non-zero status code.
 
 You can optionally pass a list of files and directories to search as arguments.
 
-```
-$ ripsecrets file1 file2 dir1
+```shell
+ripsecrets file1 file2 dir1
 ```
 
-This is most commonly used to search files that are about to be committed to source control for accidentally included secrets. 
+This is most commonly used to search files that are about to be committed to source control for accidentally included secrets.
 
-### Installing ripsecrets as a pre-commit hook 
+### Installing ripsecrets as a pre-commit hook
 
 You can install `ripsecrets` as a pre-commit hook _automatically_ in your current git repository using the following command:
 
-```
-$ ripsecrets --install-pre-commit
+```shell
+ripsecrets --install-pre-commit
 ```
 
 If you would like to install `ripsecrets` _manually_, you can add the following command to your `pre-commit` script:
 
-```
+```shell
 ripsecrets --strict-ignore `git diff --cached --name-only --diff-filter=ACM`
 ```
 
@@ -58,8 +58,8 @@ Passing `--strict-ignore` ensures that your `.secretsignore` file is respected w
 
 [`ripsecrets`](https://formulae.brew.sh/formula/ripsecrets) is available in Homebrew for macOS and Linux:
 
-```
-$ brew install ripsecrets
+```shell
+brew install ripsecrets
 ```
 
 ### Pre-built
@@ -70,15 +70,16 @@ You can download a prebuilt binary for the latest release from the [releases](ht
 
 Alternatively, if you have [Rust](https://www.rust-lang.org/tools/install) and Cargo installed, you can run:
 
-```
-$ cargo install --git https://github.com/sirwart/ripsecrets --branch main
+```shell
+cargo install --git https://github.com/sirwart/ripsecrets --branch main
 ```
 
 ### Nix Flake
 
 Assuming you have enabled [Flakes](https://nixos.wiki/wiki/Flakes) in your Nix configuration, you can build the `ripsecrets` binary and make it available in your default Nix profile by running:
-```
-$ nix profile install github:sirwart/ripsecrets
+
+```shell
+nix profile install github:sirwart/ripsecrets
 ```
 
 ### Using `pre-commit`
@@ -88,11 +89,11 @@ Add the following to your `.pre-commit-config.yaml` file:
 
 ```yaml
 repos:
--   repo: https://github.com/sirwart/ripsecrets
-    rev: v0.1.7  # Use latest tag on GitHub
+  - repo: https://github.com/sirwart/ripsecrets
+    rev: v0.1.7 # Use latest tag on GitHub
     hooks:
-    -   id: ripsecrets
-        # uncomment to check additional patterns 
+      - id: ripsecrets
+        # uncomment to check additional patterns
         # args:
         # - --additional-pattern 'mytoken*'
         # - --additional-pattern 'mykey*'
@@ -102,20 +103,20 @@ There are two hooks available:
 
 - `ripsecrets` (Recommended)
 
-   pre-commit will set up a Rust environment from scratch to compile and run ripsecrets.
-   See the [pre-commit rust plugin docs](https://pre-commit.com/#rust) for more information.
+  pre-commit will set up a Rust environment from scratch to compile and run ripsecrets.
+  See the [pre-commit rust plugin docs](https://pre-commit.com/#rust) for more information.
 
 - `ripsecrets-system`
 
-   pre-commit will look for `ripsecrets` on your `PATH`.
-   This hook requires you to install ripsecrets separately, e.g., with your package manager or [a prebuilt binary release](https://github.com/sirwart/ripsecrets/releases).
-   It is only recommended if you are happy making all repository users install `ripsecrets` manually.
+  pre-commit will look for `ripsecrets` on your `PATH`.
+  This hook requires you to install ripsecrets separately, e.g., with your package manager or [a prebuilt binary release](https://github.com/sirwart/ripsecrets/releases).
+  It is only recommended if you are happy making all repository users install `ripsecrets` manually.
 
 ## Ignoring secrets
 
 `ripsecrets` will respect your .gitignore files by default, but there might still be files you want to exclude from being scanned for secrets. To do that, you can create a .secretsignore file, which supports similar syntax to a .gitignore file for ignoring files. In addition to excluding files, it also supports a `[secrets]` section that allows ignoring individual secrets.
 
-```
+```text
 test/*
 dummy
 
@@ -125,7 +126,7 @@ pAznMW3DsrnVJ5TDWwBVCA
 
 In addition to the .secretsignore file, `ripsecrets` is compatible with `detect-secrets` style allowlist comments on the same line as the detected secret:
 
-```
+```text
 test_secret = "pAznMW3DsrnVJ5TDWwBVCA" # pragma: allowlist secret
 ```
 
@@ -133,7 +134,7 @@ test_secret = "pAznMW3DsrnVJ5TDWwBVCA" # pragma: allowlist secret
 
 In some cases, you may have a custom secret that's not recognized by `ripsecrets`. To detect these, call `ripsecrets` with the `--additional-pattern` argument:
 
-```
+```shell
 ripsecrets --additional-pattern my-secret-\*
 ```
 
@@ -143,7 +144,7 @@ If the secret pattern you're trying to detect is a publicly documented secret pa
 
 ## How it works
 
- `ripsecrets` has 2 types of secrets that it can find in code:
+`ripsecrets` has 2 types of secrets that it can find in code:
 
 1. Secrets with known patterns that can be matched. API keys from services like Stripe and Slack have a predefined prefix that identifies them as API keys and can be found via regular expressions very reliably. You can see the current list of known secrets matched by `ripsecrets` [here](https://github.com/sirwart/ripsecrets/blob/main/src/lib.rs#L22).
 
@@ -173,10 +174,7 @@ Most of the time, your pre-commit will be running on a small number of files, so
 
 ## Running benchmarks
 
-```shell
-$ cargo bench
-```
-
+Benchmarks are run via `cargo bench`.
 The results will then be viewable at `target/criterion/report/index.html`.
 
 ## Alternative tools

--- a/flake.nix
+++ b/flake.nix
@@ -113,8 +113,12 @@
             hooks = {
               editorconfig-checker.enable = true;
               markdownlint.enable = true;
+              mdsh.enable = true;
               nixfmt.enable = true;
-              prettier.enable = true;
+              prettier = {
+                enable = true;
+                excludes = [ ".*.md" ];
+              };
               rustfmt.enable = true;
               typos = {
                 enable = true;

--- a/flake.nix
+++ b/flake.nix
@@ -112,6 +112,7 @@
             src = ./.;
             hooks = {
               editorconfig-checker.enable = true;
+              markdownlint.enable = true;
               nixfmt.enable = true;
               rustfmt.enable = true;
               typos = {

--- a/flake.nix
+++ b/flake.nix
@@ -114,6 +114,7 @@
               editorconfig-checker.enable = true;
               markdownlint.enable = true;
               nixfmt.enable = true;
+              prettier.enable = true;
               rustfmt.enable = true;
               typos = {
                 enable = true;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,8 @@ pub fn find_secrets(
 ) -> Result<usize, Box<dyn Error>> {
     let predefined_patterns = predefined_secret_regexes();
 
-    let mut all_patterns: Vec<&str> = Vec::with_capacity(predefined_patterns.len() + additional_patterns.len());
+    let mut all_patterns: Vec<&str> =
+        Vec::with_capacity(predefined_patterns.len() + additional_patterns.len());
     all_patterns.extend(predefined_patterns.iter());
     for p in additional_patterns {
         all_patterns.push(p.as_str());

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,12 @@ pub enum UsageError {
     about,
     name = "ripsecrets",
     long_about = "ripsecrets searches files and directories recursively for secret API keys.
-It's primarily designed to be used as a pre-commit to prevent committing
-secrets into version control."
+
+ripsecrets is primarily designed to be used as a pre-commit to prevent committing secrets into version control.
+
+For every secret it finds, ripsecrets will print out the file, line number, and the secret that was found.  If ripsecrets finds any secrets, it will exit with a non-zero status code.
+
+You can optionally pass a list of files and directories to search as arguments.  This is most commonly used to search files that are about to be committed to source control for accidentally included secrets."
 )]
 struct Args {
     /// Install `ripsecrets` as a pre-commit hook automatically in git directory provided. Defaults to

--- a/src/matcher/mod.rs
+++ b/src/matcher/mod.rs
@@ -57,9 +57,7 @@ impl Matcher for IgnoringMatcher {
     fn find_at(&self, haystack: &[u8], at: usize) -> Result<Option<Match>, NoError> {
         let mut pos = at;
         while pos < haystack.len() {
-            let captures = self
-                .regex
-                .captures_at(haystack, pos);
+            let captures = self.regex.captures_at(haystack, pos);
             match captures {
                 None => return Ok(None),
                 Some(captures) => {

--- a/src/matcher/p_random.rs
+++ b/src/matcher/p_random.rs
@@ -1,6 +1,6 @@
+use regex::bytes::Regex;
 use std::collections::hash_map::HashMap;
 use std::collections::hash_set::HashSet;
-use regex::bytes::Regex;
 
 use memoize::memoize;
 
@@ -20,7 +20,11 @@ lazy_static::lazy_static! {
 /// This math is probably not perfect, but it should be in the right ballpark and it's ultimately a heuristic so it should
 /// be judged on how well it's able to distinguish random from non-random text.
 pub fn p_random(s: &[u8]) -> f64 {
-    let base = if RANDOM_STRING_REGEX.is_match(s) { 16.0 } else { 64.0 };
+    let base = if RANDOM_STRING_REGEX.is_match(s) {
+        16.0
+    } else {
+        64.0
+    };
     let mut p = p_random_distinct_values(s, base) * p_random_char_class(s, base);
     if base == 64.0 {
         // right now the bigrams are only calibrated for base64
@@ -55,11 +59,7 @@ fn p_random_char_class(s: &[u8], base: f64) -> f64 {
         return p_random_char_class_aux(s, b'0', b'9', 16.0);
     } else {
         let mut min_p = f64::INFINITY;
-        let char_classes = [
-            (b'0', b'9'),
-            (b'A', b'Z'),
-            (b'a', b'z'),
-        ];
+        let char_classes = [(b'0', b'9'), (b'A', b'Z'), (b'a', b'z')];
         for (min, max) in char_classes {
             let p = p_random_char_class_aux(s, min, max, base);
             if p < min_p {


### PR DESCRIPTION
The help information that had previously been present only in the repo's README is now included in the CLI's usage text. Since that documentation is now available at runtime, the README has been updated to use `mdsh` to ensure it is kept up-to-date as the CLI's usage text changes.