### PR TITLE
Generate manpage as part of build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
+name = "clap_mangen"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3be86020147691e1d2ef58f75346a3d4d94807bfc473e377d52f09f0f7d77f7"
+dependencies = [
+ "clap 4.4.8",
+ "roff",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +721,7 @@ name = "ripsecrets"
 version = "0.1.7"
 dependencies = [
  "clap 4.4.8",
+ "clap_mangen",
  "criterion",
  "grep",
  "ignore",
@@ -721,6 +732,12 @@ dependencies = [
  "tempfile",
  "termcolor",
 ]
+
+[[package]]
+name = "roff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,6 @@ criterion = { version = "0.3", features = ["html_reports"] }
 name = "find_secrets"
 harness = false
 
+[build-dependencies]
+clap = { version = "4.2.5", features = ["derive"] }
+clap_mangen = "0.2.15"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,21 @@
+include!("src/args.rs");
+
+fn main() -> std::io::Result<()> {
+    // Tell Cargo that if the given file changes, to rerun this build script.
+    println!("cargo:rerun-if-changed=src/args.rs");
+
+    let out_dir =
+        std::path::PathBuf::from(std::env::var_os("OUT_DIR").ok_or(std::io::ErrorKind::NotFound)?);
+
+    let cmd = <Args as clap::CommandFactory>::command();
+
+    let man = clap_mangen::Man::new(cmd);
+    let mut buffer: Vec<u8> = Default::default();
+    man.render(&mut buffer)?;
+
+    println!("{:?}", buffer);
+
+    std::fs::write(out_dir.join("ripsecrets.1"), buffer)?;
+
+    Ok(())
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use std::path::PathBuf;
 
-/// Prevent committing secret keys into your source code
+/// Prevent committing secret keys into your source code.
 #[derive(Parser, Debug)]
 #[clap(
     version,
@@ -12,8 +12,7 @@ It's primarily designed to be used as a pre-commit to prevent committing
 secrets into version control."
 )]
 struct Args {
-    /// Install `ripsecrets` as a pre-commit hook automatically in git directory provided. Defaults to
-    /// '.'
+    /// Install `ripsecrets` as a pre-commit hook automatically in git directory provided.
     #[clap(long = "install-pre-commit")]
     install_pre_commit: bool,
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,42 @@
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Prevent committing secret keys into your source code
+#[derive(Parser, Debug)]
+#[clap(
+    version,
+    about,
+    name = "ripsecrets",
+    long_about = "ripsecrets searches files and directories recursively for secret API keys.
+It's primarily designed to be used as a pre-commit to prevent committing
+secrets into version control."
+)]
+struct Args {
+    /// Install `ripsecrets` as a pre-commit hook automatically in git directory provided. Defaults to
+    /// '.'
+    #[clap(long = "install-pre-commit")]
+    install_pre_commit: bool,
+
+    /// If you pass a path as an argument that's ignored by .secretsignore it
+    /// will be scanned by default. --strict-ignore will override this
+    /// behavior and not search the paths passed as arguments that are excluded
+    /// by the .secretsignore file. This is useful when invoking secrets as a
+    /// pre-commit.
+    #[clap(long = "strict-ignore")]
+    strict_ignore: bool,
+
+    /// Print only the matched (non-empty) parts of a matching line, with each such
+    /// part on a separate output line.
+    #[clap(long = "only-matching")]
+    only_matching: bool,
+
+    /// Additional regex patterns used to find secrets. If there is a matching
+    /// group in the regex the matched group will be tested for randomness before
+    /// being reported as a secret.
+    #[clap(long = "additional-pattern")]
+    additional_patterns: Vec<String>,
+
+    /// Source files. Can be files or directories. Defaults to '.'
+    #[clap(name = "Source files")]
+    paths: Vec<PathBuf>,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,58 +1,18 @@
 #![allow(clippy::needless_return)]
 
-use clap::Parser;
 use ripsecrets::find_secrets;
-use std::path::PathBuf;
 use std::process;
 use termcolor::{BufferWriter, ColorChoice};
 
 mod pre_commit;
+
+include!("args.rs");
 
 #[derive(Debug)]
 pub enum UsageError {
     PreCommit,
     Version,
     Help,
-}
-
-/// Prevent committing secret keys into your source code
-#[derive(Parser, Debug)]
-#[clap(
-    version,
-    about,
-    name = "ripsecrets",
-    long_about = "ripsecrets searches files and directories recursively for secret API keys.
-It's primarily designed to be used as a pre-commit to prevent committing
-secrets into version control."
-)]
-struct Args {
-    /// Install `ripsecrets` as a pre-commit hook automatically in git directory provided. Defaults to
-    /// '.'
-    #[clap(long = "install-pre-commit")]
-    install_pre_commit: bool,
-
-    /// If you pass a path as an argument that's ignored by .secretsignore it
-    /// will be scanned by default. --strict-ignore will override this
-    /// behavior and not search the paths passed as arguments that are excluded
-    /// by the .secretsignore file. This is useful when invoking secrets as a
-    /// pre-commit.
-    #[clap(long = "strict-ignore")]
-    strict_ignore: bool,
-
-    /// Print only the matched (non-empty) parts of a matching line, with each such
-    /// part on a separate output line.
-    #[clap(long = "only-matching")]
-    only_matching: bool,
-
-    /// Additional regex patterns used to find secrets. If there is a matching
-    /// group in the regex the matched group will be tested for randomness before
-    /// being reported as a secret.
-    #[clap(long = "additional-pattern")]
-    additional_patterns: Vec<String>,
-
-    /// Source files. Can be files or directories. Defaults to '.'
-    #[clap(name = "Source files")]
-    paths: Vec<PathBuf>,
 }
 
 enum RunResult {


### PR DESCRIPTION
Fixes #73 by generated a manpage via `clap_mangen`.

<details>
<summary>This is the output nroff I get when building locally.</summary>

```nroff
.ie \n(.g .ds Aq \(aq
.el .ds Aq '
.TH ripsecrets 1  "ripsecrets 0.1.7" 
.SH NAME
ripsecrets \- A command\-line tool to prevent committing secret keys into your source code
.SH SYNOPSIS
\fBripsecrets\fR [\fB\-\-install\-pre\-commit\fR] [\fB\-\-strict\-ignore\fR] [\fB\-\-only\-matching\fR] [\fB\-\-additional\-pattern\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fISource files\fR] 
.SH DESCRIPTION
ripsecrets searches files and directories recursively for secret API keys.
It\*(Aqs primarily designed to be used as a pre\-commit to prevent committing
secrets into version control.
.SH OPTIONS
.TP
\fB\-\-install\-pre\-commit\fR
Install `ripsecrets` as a pre\-commit hook automatically in git directory provided
.TP
\fB\-\-strict\-ignore\fR
If you pass a path as an argument that\*(Aqs ignored by .secretsignore it will be scanned by default. \-\-strict\-ignore will override this behavior and not search the paths passed as arguments that are excluded by the .secretsignore file. This is useful when invoking secrets as a pre\-commit
.TP
\fB\-\-only\-matching\fR
Print only the matched (non\-empty) parts of a matching line, with each such part on a separate output line
.TP
\fB\-\-additional\-pattern\fR=\fIADDITIONAL_PATTERNS\fR
Additional regex patterns used to find secrets. If there is a matching group in the regex the matched group will be tested for randomness before being reported as a secret
.TP
\fB\-h\fR, \fB\-\-help\fR
Print help (see a summary with \*(Aq\-h\*(Aq)
.TP
\fB\-V\fR, \fB\-\-version\fR
Print version
.TP
[\fISource files\fR]
Source files. Can be files or directories. Defaults to \*(Aq.\*(Aq
.SH VERSION
v0.1.7
```

</details>