### PR TITLE
Update Flake inputs to account for Cargo v4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1723137097,
-        "narHash": "sha256-Q/TeuIV610BJ39UkP4zRm6pG6BWEaOCih/WXNR2V9rk=",
+        "lastModified": 1735408444,
+        "narHash": "sha256-Bcf7iBwrfjYPO7roKCz+3yPAFqgNqfKCp51sLKETjxU=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "1d209d3f18c740f104380e988b5aa8eb360190d1",
+        "rev": "3c6d3186ab06737d1defd2b5ae556d0ecd161603",
         "type": "github"
       },
       "original": {
@@ -17,17 +17,12 @@
       }
     },
     "crane": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
       "locked": {
-        "lastModified": 1722960479,
-        "narHash": "sha256-NhCkJJQhD5GUib8zN9JrmYGMwt4lCRp6ZVNzIiYCl0Y=",
+        "lastModified": 1734808813,
+        "narHash": "sha256-3aH/0Y6ajIlfy7j52FGZ+s4icVX0oHhqBzRdlOeztqg=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "4c6c77920b8d44cd6660c1621dea6b3fc4b4c4f4",
+        "rev": "72e2d02dbac80c8c86bf6bf3e785536acf8ee926",
         "type": "github"
       },
       "original": {
@@ -57,11 +52,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -93,11 +88,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723421421,
-        "narHash": "sha256-ohKD5dTOkz2wUa2od3G5COc0iAF2sV4HcNVeoPOfp7U=",
+        "lastModified": 1735530358,
+        "narHash": "sha256-4ZbiXBWFK0gHsl5VT9dih7RVaEV3rRh0XUV0jW0ibOM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4e7d996aa858660e3261b4834ab00415cfe9b0fe",
+        "rev": "5000219208d860bafd1ee26eadb403449f3d9ab9",
         "type": "github"
       },
       "original": {
@@ -108,11 +103,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1720386169,
-        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
+        "lastModified": 1730741070,
+        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
+        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
         "type": "github"
       },
       "original": {
@@ -124,11 +119,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1719082008,
-        "narHash": "sha256-jHJSUH619zBQ6WdC21fFAlDxHErKVDJ5fpN0Hgx4sjs=",
+        "lastModified": 1730768919,
+        "narHash": "sha256-8AKquNnnSaJRXZxc5YmF/WfmxiHX6MMZZasRP6RRQkE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9693852a2070b398ee123a329e68f0dab5526681",
+        "rev": "a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc",
         "type": "github"
       },
       "original": {
@@ -146,11 +141,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1723202784,
-        "narHash": "sha256-qbhjc/NEGaDbyy0ucycubq4N3//gDFFH3DOmp1D3u1Q=",
+        "lastModified": 1734797603,
+        "narHash": "sha256-ulZN7ps8nBV31SE+dwkDvKIzvN6hroRY8sYOT0w+E28=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "c7012d0c18567c889b948781bc74a501e92275d1",
+        "rev": "f0f0dc4920a903c3e08f5bdb9246bb572fcae498",
         "type": "github"
       },
       "original": {
@@ -176,11 +171,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723429325,
-        "narHash": "sha256-4x/32xTCd+xCwFoI/kKSiCr5LQA2ZlyTRYXKEni5HR8=",
+        "lastModified": 1735525800,
+        "narHash": "sha256-pcN8LAL021zdC99a9F7iEiFCI1wmrE4DpIYUgKpB/jY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "65e3dc0fe079fe8df087cd38f1fe6836a0373aad",
+        "rev": "10faa81b4c0135a04716cbd1649260d82b2890cd",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,24 +4,16 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs";
-
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
+    crane.url = "github:ipetkov/crane";
     flake-utils.url = "github:numtide/flake-utils";
-
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-
     advisory-db = {
       url = "github:rustsec/advisory-db";
       flake = false;
     };
-
     pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
   };
 

--- a/src/pre_commit.rs
+++ b/src/pre_commit.rs
@@ -56,7 +56,6 @@ pub fn install_pre_commit(repo_root: &Path) -> Result<(), Box<dyn Error>> {
             {
                 None => {
                     let mut file = OpenOptions::new()
-                        .write(true)
                         .append(true)
                         .open(pre_commit_fname)
                         .unwrap();


### PR DESCRIPTION
Flake lock file updates:

- Updated input 'advisory-db':
  - From: 'github:rustsec/advisory-db/1d209d3f18c740f104380e988b5aa8eb360190d1?narHash=sha256-Q/TeuIV610BJ39UkP4zRm6pG6BWEaOCih/WXNR2V9rk%3D' (2024-08-08)
  - To: 'github:rustsec/advisory-db/3c6d3186ab06737d1defd2b5ae556d0ecd161603?narHash=sha256-Bcf7iBwrfjYPO7roKCz%2B3yPAFqgNqfKCp51sLKETjxU%3D' (2024-12-28)
- Updated input 'crane':
  - From: 'github:ipetkov/crane/4c6c77920b8d44cd6660c1621dea6b3fc4b4c4f4?narHash=sha256-NhCkJJQhD5GUib8zN9JrmYGMwt4lCRp6ZVNzIiYCl0Y%3D' (2024-08-06)
  - To: 'github:ipetkov/crane/72e2d02dbac80c8c86bf6bf3e785536acf8ee926?narHash=sha256-3aH/0Y6ajIlfy7j52FGZ%2Bs4icVX0oHhqBzRdlOeztqg%3D' (2024-12-21)
- Removed input 'crane/nixpkgs'
- Updated input 'flake-utils':
  - From:  'github:numtide/flake-utils/b1d9ab70662946ef0850d488da1c9019f3a9752a?narHash=sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ%3D' (2024-03-11)
  - To: 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b?narHash=sha256-l0KFg5HjrsfsO/JpG%2Br7fRrqm12kzFHyUHqHCVpMMbI%3D' (2024-11-13)
- Updated input 'nixpkgs':
  - From:  'github:NixOS/nixpkgs/4e7d996aa858660e3261b4834ab00415cfe9b0fe?narHash=sha256-ohKD5dTOkz2wUa2od3G5COc0iAF2sV4HcNVeoPOfp7U%3D' (2024-08-12)
  - To: 'github:NixOS/nixpkgs/5000219208d860bafd1ee26eadb403449f3d9ab9?narHash=sha256-4ZbiXBWFK0gHsl5VT9dih7RVaEV3rRh0XUV0jW0ibOM%3D' (2024-12-30)
- Updated input 'pre-commit-hooks':
  - From:  'github:cachix/pre-commit-hooks.nix/c7012d0c18567c889b948781bc74a501e92275d1?narHash=sha256-qbhjc/NEGaDbyy0ucycubq4N3//gDFFH3DOmp1D3u1Q%3D' (2024-08-09)
  - To: 'github:cachix/pre-commit-hooks.nix/f0f0dc4920a903c3e08f5bdb9246bb572fcae498?narHash=sha256-ulZN7ps8nBV31SE%2BdwkDvKIzvN6hroRY8sYOT0w%2BE28%3D' (2024-12-21)
- Updated input 'pre-commit-hooks/nixpkgs':
  - From:  'github:NixOS/nixpkgs/9693852a2070b398ee123a329e68f0dab5526681?narHash=sha256-jHJSUH619zBQ6WdC21fFAlDxHErKVDJ5fpN0Hgx4sjs%3D' (2024-06-22)
  - To: 'github:NixOS/nixpkgs/a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc?narHash=sha256-8AKquNnnSaJRXZxc5YmF/WfmxiHX6MMZZasRP6RRQkE%3D' (2024-11-05)
- Updated input 'pre-commit-hooks/nixpkgs-stable':
  - From:  'github:NixOS/nixpkgs/194846768975b7ad2c4988bdb82572c00222c0d7?narHash=sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo%3D' (2024-07-07)
  - To: 'github:NixOS/nixpkgs/d063c1dd113c91ab27959ba540c0d9753409edf3?narHash=sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo%3D' (2024-11-04)
- Updated input 'rust-overlay':
  - From:  'github:oxalica/rust-overlay/65e3dc0fe079fe8df087cd38f1fe6836a0373aad?narHash=sha256-4x/32xTCd%2BxCwFoI/kKSiCr5LQA2ZlyTRYXKEni5HR8%3D' (2024-08-12)
  - To: 'github:oxalica/rust-overlay/10faa81b4c0135a04716cbd1649260d82b2890cd?narHash=sha256-pcN8LAL021zdC99a9F7iEiFCI1wmrE4DpIYUgKpB/jY%3D' (2024-12-30)