### PR TITLE
secretsignore file pattern has the highest precedence

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ pub fn find_secrets(
         walk_builder.add(additional_path);
     }
     if ignore_info.ignore_file_path.is_some() {
-        walk_builder.add_ignore(ignore_info.ignore_file_path.unwrap());
+        walk_builder.add_custom_ignore_filename(ignore_info.ignore_file_path.unwrap());
     }
 
     let parallel_walker = walk_builder


### PR DESCRIPTION
Currently, the secretsignore specified files are added with the lowest precedence, so if some other regular gitignore file happens to unignore some pattern (i.e. with `!pattern`), its not easy to have the ripsecrets ignore these files.

This PR changes the behavior so that the file patterns from the secretsignore have the highest precedence. Im happy to modify this to flag this behavior, because this does potentially cause some difference in behavior, but I think that the previous behavior seemed unintended.
