### PR TITLE
chore: update upload-artifact to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'The tag to emulate'
+        description: "The tag to emulate"
         required: true
         type: string
 
@@ -61,7 +61,7 @@ jobs:
         run: nix build .#ripsecrets-oci
 
       - name: Temporarily save the OCI archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: oci-tar-gz-${{ needs.determine-tag.outputs.version }}
           path: result
@@ -110,5 +110,4 @@ jobs:
       - name: Publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_API_TOKEN }}
-        run:
-          nix develop --command cargo publish
+        run: nix develop --command cargo publish


### PR DESCRIPTION
upload-artifact v3 was deprecated.

https://github.com/actions/upload-artifact

> Warning
> actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024. [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) Similarly, v1/v2 are scheduled for deprecation on June 30, 2024. Please update your workflow to use v4 of the artifact actions.

CI failed and outputted the log `Error: Missing download info for actions/upload-artifact@v3`.

- https://github.com/sirwart/ripsecrets/issues/95

I'm not sure if this is related to the deprecation, but we should update the action.