### PR TITLE
ci: checkout the repository before running install-nix-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+
       - name: Install and configure Nix
         uses: cachix/install-nix-action@v25
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install and configure Nix
         uses: cachix/install-nix-action@v25
 


### PR DESCRIPTION
Checkout the repository before running install-nix-action.

CI failed.

- https://github.com/sirwart/ripsecrets/issues/95

https://github.com/sirwart/ripsecrets/actions/runs/14021086096/job/39253150448

```
Run nix develop --command cargo publish
path '/home/runner/work/ripsecrets/ripsecrets' does not contain a 'flake.nix', searching up
error: could not find a flake.nix file
Error: Process completed with exit code 1.
```

flake.nix exists in the repository, but the repository wasn't checked out.

https://github.com/sirwart/ripsecrets/blob/main/flake.nix