### PR TITLE
fix: sync Cargo.toml and Cargo.lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.11 (2025-05-26)
+
+- Fix Cargo.lock file
+
 ## 0.1.10 (2025-05-26)
 
 - Increased max random string length to catch terraform secrets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "ripsecrets"
-version = "0.1.9"
+version = "0.1.11"
 dependencies = [
  "clap 4.5.23",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ripsecrets"
 description = "A command-line tool to prevent committing secret keys into your source code"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 repository = "https://github.com/sirwart/ripsecrets"
 homepage = "https://github.com/sirwart/ripsecrets"


### PR DESCRIPTION
Fixes https://github.com/sirwart/ripsecrets/actions/runs/15265566715/job/42930528887#step:4:753,

> ++ command cargo check --release --locked --all-targets
> error: the lock file /build/source/Cargo.lock needs to be updated but --locked was passed to prevent this
> If you want to try to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.