### PR TITLE
Remove `refs/tags/` prefix from tag in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         id: on-push
         if: ${{ github.event_name == 'push' }}
         run: |
-          echo "tag=${{ github.ref }}" >> $GITHUB_OUTPUT
+          echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
 
       - name: Use workflow input
         id: on-workflow


### PR DESCRIPTION
The difference between `github.ref` and `github.ref_name` is documented in https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context.